### PR TITLE
Refactor logger configuration and enhance documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ handler := otel.New(
 )
 ```
 
+Avoid enabling all baggage in production unless the upstream context is already
+sanitized. Baggage can contain tenant identifiers, tokens, or other sensitive
+values; use `WithBaggageAllowList`, `WithBaggageDenyList`, or
+`WithBaggageFilter` to keep log output intentional.
+
 <hr>
 
 Released under the [GPL-3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # Log v1
 
-Simple, fast, structured and level registration in Go.
+Structured logging built on top of `log/slog`.
 
 ## Overview
 
-This package offers several functions that allow you to trace controlled log errors in the files and functions where they occur, as well as useful programmer log comments in your code. This package will help you identify and segment the different types of errors log or unique circumstances during the execution of your program using criteria according to the level of impact on the business rules of its development. The package prints the useful information for the programmer in a human readable format.
+This package wraps `slog` with:
+
+- package-level helpers for common log levels
+- source metadata on each record
+- stack traces on debug logs
+- optional OpenTelemetry correlation via `otel`
 
 ## Installation
 
-`go get -u https://github.com/jgolang/log`
+`go get github.com/jgolang/log`
 
 ## Quick Start
 
@@ -18,34 +23,25 @@ package main
 import "github.com/jgolang/log"
 
 func main(){
-    log.Println("My info....")
+    log.Info("My info....")
 }
 ```
 
-### Terminal output:
+### Output:
 
 ```terminal
-2020/07/05 13:32:03     INFO    /dir/file.go:10 (function) My info...
+{"time":"2026-05-02T10:00:00Z","level":"INFO","msg":"My info....","source":{"func":"main","file":"main.go","line":6}}
 ```
 
-## Mode
+## Configuration
 
-You can configure the package depending on your needs to display certain types of log by defining an environment variable on the system that runs your program.
-
+```go
+log.SetLevel(slog.LevelWarn)
+log.NewTextHandler()
 ```
-[user@ /home]# export MODE="DEV"
-```
 
-### Allowed modes 
-
-| Mode | Description |
-| :------ | :--: | 
-| PROD | Only prints error log | 
-| DEV | Print all | 
-
-Note: Error logs are printed regardless of this setting.
+The package no longer depends on a `MODE` environment variable.
 
 <hr>
 
-Released under the [GPL-3.0](LICENSE.txt).
-
+Released under the [GPL-3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ sanitized. Baggage can contain tenant identifiers, tokens, or other sensitive
 values; use `WithBaggageAllowList`, `WithBaggageDenyList`, or
 `WithBaggageFilter` to keep log output intentional.
 
+## Verification
+
+```bash
+go test ./...
+go test -race ./...
+go vet ./...
+go test -bench=. -run=^$ ./...
+```
+
+Use the benchmarks to compare source metadata, disabled levels, and debug stack
+traces before changing logger internals.
+
 <hr>
 
 Released under the [GPL-3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -38,9 +38,38 @@ func main(){
 ```go
 log.SetLevel(slog.LevelWarn)
 log.NewTextHandler()
+log.SetSource(true)
+log.SetDebugStackTrace(false)
 ```
 
 The package no longer depends on a `MODE` environment variable.
+Debug stack traces are now opt-in.
+
+## Instance API
+
+```go
+logger := log.New(
+    log.WithLevel(slog.LevelInfo),
+    log.WithTextHandler(os.Stdout),
+    log.WithSource(true),
+    log.WithDebugStackTrace(false),
+)
+
+logger.Info("service started")
+```
+
+## OpenTelemetry
+
+The `otel` handler now disables baggage logging by default.
+If you need baggage in logs, enable it explicitly and prefer an allow-list:
+
+```go
+handler := otel.New(
+    slog.NewJSONHandler(os.Stdout, nil),
+    otel.WithNoBaggage(false),
+    otel.WithBaggageAllowList("request_id", "tenant"),
+)
+```
 
 <hr>
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,9 @@
+# Release Checklist
+
+Before tagging a release:
+
+- Run `go test ./...`, `go test -race ./...`, and `go vet ./...`.
+- Run `go test -bench=. ./...` when logging performance changed.
+- Review exported API changes with `go doc ./...`; deprecate before removing public names.
+- Confirm README examples still match current defaults.
+- Confirm OTel baggage logging remains opt-in and documented with filtering guidance.

--- a/config.go
+++ b/config.go
@@ -1,0 +1,46 @@
+package log
+
+import (
+	"io"
+	"log/slog"
+
+	"github.com/jgolang/log/logger"
+)
+
+type Logger = logger.Logger
+type Option = logger.Option
+
+func WithLevel(level slog.Level) Option {
+	return logger.WithLevel(level)
+}
+
+func WithSource(enabled bool) Option {
+	return logger.WithSource(enabled)
+}
+
+func WithDebugStackTrace(enabled bool) Option {
+	return logger.WithDebugStackTrace(enabled)
+}
+
+func WithJSONHandler(w io.Writer) Option {
+	return logger.WithJSONHandler(w)
+}
+
+func WithTextHandler(w io.Writer) Option {
+	return logger.WithTextHandler(w)
+}
+
+// New creates a configurable logger instance without touching package-level state.
+func New(opts ...Option) *Logger {
+	return logger.NewWithOptions(opts...)
+}
+
+// SetSource controls whether package-level logs include source metadata.
+func SetSource(enabled bool) {
+	std.SetSource(enabled)
+}
+
+// SetDebugStackTrace controls whether package-level debug logs include stack traces.
+func SetDebugStackTrace(enabled bool) {
+	std.SetDebugStackTrace(enabled)
+}

--- a/doc.go
+++ b/doc.go
@@ -38,6 +38,20 @@
 //
 //  log.SetLevel(slog.LevelWarn)
 //  log.NewTextHandler()
+//  log.SetSource(true)
+//  log.SetDebugStackTrace(false)
 //
-// The package does not depend on environment variables.
+// The package does not depend on environment variables, and debug stack
+// traces are opt-in.
+//
+// You can also build isolated logger instances:
+//
+//  logger := log.New(
+//      log.WithLevel(slog.LevelInfo),
+//      log.WithTextHandler(os.Stdout),
+//      log.WithSource(true),
+//      log.WithDebugStackTrace(false),
+//  )
+//
+//  logger.Info("service started")
 package log

--- a/doc.go
+++ b/doc.go
@@ -5,22 +5,16 @@
 // Everyone is permitted to copy and distribute verbatim copies
 // of this license document, but changing it is not allowed.
 
-// Package log provides simple, fast, structured and level registration in Go.
+// Package log provides structured logging helpers built on top of log/slog.
 //
-// This package offers several functions that allow you to trace
-// controlled log errors in the files and functions where they occur,
-// as well as useful programmer log comments in your code. This package
-// will help you identify and segment the different types of errors log
-// or unique circumstances during the execution of your program using
-// criteria according to the level of impact on the business rules of
-// its development. The package prints the useful information for the
-// programmer in a human readable format.
+// The package adds source metadata to every record, stack traces to debug
+// records, and OpenTelemetry integration through the otel subpackage.
 //
 // Installation
 //
 // Run command in terminal:
 //
-//  go get -u https://github.com/jgolang/log
+//  go get github.com/jgolang/log
 //
 // Quick Start
 //
@@ -31,24 +25,19 @@
 //  import "github.com/jgolang/log"
 //
 //  func main(){
-//      log.Println("My info....")
+//      log.Info("My info....")
 //  }
 //
-// Terminal output:
+// Output:
 //
-//  2020/07/05 13:32:03     INFO    /dir/file.go:10 (function) My info...
+//  {"time":"2026-05-02T10:00:00Z","level":"INFO","msg":"My info....","source":{"func":"main","file":"main.go","line":6}}
 //
-// Configuration Modes
+// Configuration
 //
-// You can configure the package depending on your needs to display certain
-// types of log by defining an environment variable on the system that runs
-// your program.
+// You can configure the current level and handler programmatically:
 //
-//  [user@ /home]# export MODE="DEV"
+//  log.SetLevel(slog.LevelWarn)
+//  log.NewTextHandler()
 //
-// Allowed modes
-//
-//  PROD | DEV
-//
-// Note: Error logs are printed regardless of this setting.
+// The package does not depend on environment variables.
 package log

--- a/doc.go
+++ b/doc.go
@@ -10,48 +10,52 @@
 // The package adds source metadata to every record, stack traces to debug
 // records, and OpenTelemetry integration through the otel subpackage.
 //
-// Installation
+// # Installation
 //
 // Run command in terminal:
 //
-//  go get github.com/jgolang/log
+//	go get github.com/jgolang/log
 //
-// Quick Start
+// # Quick Start
 //
 // This is a simple example of how the package is implemented with a basic function.
 //
-//  package main
+//	package main
 //
-//  import "github.com/jgolang/log"
+//	import "github.com/jgolang/log"
 //
-//  func main(){
-//      log.Info("My info....")
-//  }
+//	func main(){
+//	    log.Info("My info....")
+//	}
 //
 // Output:
 //
-//  {"time":"2026-05-02T10:00:00Z","level":"INFO","msg":"My info....","source":{"func":"main","file":"main.go","line":6}}
+//	{"time":"2026-05-02T10:00:00Z","level":"INFO","msg":"My info....","source":{"func":"main","file":"main.go","line":6}}
 //
-// Configuration
+// # Configuration
 //
 // You can configure the current level and handler programmatically:
 //
-//  log.SetLevel(slog.LevelWarn)
-//  log.NewTextHandler()
-//  log.SetSource(true)
-//  log.SetDebugStackTrace(false)
+//	log.SetLevel(slog.LevelWarn)
+//	log.NewTextHandler()
+//	log.SetSource(true)
+//	log.SetDebugStackTrace(false)
 //
 // The package does not depend on environment variables, and debug stack
 // traces are opt-in.
 //
+// The otel subpackage disables baggage logging by default. If baggage is
+// enabled, prefer allow-lists or explicit filters so sensitive context values
+// are not written to logs accidentally.
+//
 // You can also build isolated logger instances:
 //
-//  logger := log.New(
-//      log.WithLevel(slog.LevelInfo),
-//      log.WithTextHandler(os.Stdout),
-//      log.WithSource(true),
-//      log.WithDebugStackTrace(false),
-//  )
+//	logger := log.New(
+//	    log.WithLevel(slog.LevelInfo),
+//	    log.WithTextHandler(os.Stdout),
+//	    log.WithSource(true),
+//	    log.WithDebugStackTrace(false),
+//	)
 //
-//  logger.Info("service started")
+//	logger.Info("service started")
 package log

--- a/example_test.go
+++ b/example_test.go
@@ -23,6 +23,4 @@ func ExampleInfo_info() {
 	// Use this function to see the trace of execution of the sentence.
 	// This function is useful for tracking where errors are generated.
 	log.Info("Hello world!")
-	// Output:
-	// {"level":"info","ts":"1599292300.656843","flags":"","caller":"hello.com/package/file.go:10","msg":"Hello world!"}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jgolang/log
 go 1.22.5
 
 require (
-	github.com/jgolang/errors v0.1.9
+	github.com/jgolang/errors v0.2.0
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/trace v1.28.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8b
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/jgolang/errors v0.1.9 h1:/IuuwC3zM3g++LXTH5fw6voGfEFoaQa9iSsPCMGalAU=
-github.com/jgolang/errors v0.1.9/go.mod h1:HMFh/3IIKILAnWj00X771oGK6Nk3C7Sf0yZYimo9HJg=
+github.com/jgolang/errors v0.2.0 h1:/ssOg0eTY0g9gU/rU7T4ber7ZqfvrF9/uMdP+eU3yQQ=
+github.com/jgolang/errors v0.2.0/go.mod h1:HMFh/3IIKILAnWj00X771oGK6Nk3C7Sf0yZYimo9HJg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/log.go
+++ b/log.go
@@ -9,32 +9,19 @@ import (
 	"github.com/jgolang/log/logger"
 )
 
-var pc = make([]uintptr, 10)
+var level = new(slog.LevelVar)
 
-var std = logger.New(3, pc)
-
-var level = slog.LevelDebug
-
-func init() {
-	NewJSONHandler()
-}
+var std = func() *logger.Logger {
+	level.Set(slog.LevelDebug)
+	return logger.New(3, nil, level)
+}()
 
 func NewJSONHandler() {
-	opts := &slog.HandlerOptions{
-		Level: level,
-		// ReplaceAttr: logger.ReplaceAttr,
-	}
-	logger := slog.New(slog.NewJSONHandler(os.Stderr, opts))
-	slog.SetDefault(logger)
+	std.SetJSONHandler(os.Stderr)
 }
 
 func NewTextHandler() {
-	opts := &slog.HandlerOptions{
-		Level: level,
-		// ReplaceAttr: logger.ReplaceAttr,
-	}
-	logger := slog.New(slog.NewTextHandler(os.Stderr, opts))
-	slog.SetDefault(logger)
+	std.SetTextHandler(os.Stderr)
 }
 
 // SetCalldepth configure the number of stack frames
@@ -64,13 +51,12 @@ func SetCalldepth(calldepth int) {
 //	// You can restore the old level if needed
 //	logger.SetLevel(oldLevel)
 func SetLevel(newLevel slog.Level) (oldLevel slog.Level) {
-	level = newLevel
 	return std.SetLevel(newLevel)
 }
 
 // Level return current log level
 func Level() slog.Level {
-	return level
+	return level.Level()
 }
 
 func validateArgs(args ...any) (string, []any) {
@@ -78,7 +64,7 @@ func validateArgs(args ...any) (string, []any) {
 		return "", nil
 	}
 	var msg string
-	var rest []interface{}
+	var rest []any
 	switch v := args[0].(type) {
 	case string:
 		msg = v
@@ -88,10 +74,14 @@ func validateArgs(args ...any) (string, []any) {
 		rest = args[1:]
 		err, ok := v.(*errors.Error)
 		if ok {
+			debug := ""
+			if err.Wrapper != nil {
+				debug = err.Wrapper.Error()
+			}
 			errGroup := slog.Group("error",
 				"code", err.Code.Str(),
 				"msg", err.Code.Msg(),
-				"debug", err.Wrapper.Error(),
+				"debug", debug,
 				"origin", err.StackTrace(),
 			)
 			rest = append(rest, errGroup)

--- a/log_benchmark_test.go
+++ b/log_benchmark_test.go
@@ -1,0 +1,67 @@
+package log
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
+
+func BenchmarkLoggerInfo(b *testing.B) {
+	tests := []struct {
+		name       string
+		addSource  bool
+		debugStack bool
+		level      slog.Level
+		log        func(*Logger)
+	}{
+		{
+			name:      "source_on",
+			addSource: true,
+			level:     slog.LevelInfo,
+			log: func(logger *Logger) {
+				logger.Info("hello", "request_id", "abc")
+			},
+		},
+		{
+			name:      "source_off",
+			addSource: false,
+			level:     slog.LevelInfo,
+			log: func(logger *Logger) {
+				logger.Info("hello", "request_id", "abc")
+			},
+		},
+		{
+			name:       "debug_stack_on",
+			addSource:  true,
+			debugStack: true,
+			level:      slog.LevelDebug,
+			log: func(logger *Logger) {
+				logger.Debug("hello", "request_id", "abc")
+			},
+		},
+		{
+			name:      "disabled_level",
+			addSource: true,
+			level:     slog.LevelWarn,
+			log: func(logger *Logger) {
+				logger.Info("hello", "request_id", "abc")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			logger := New(
+				WithJSONHandler(io.Discard),
+				WithLevel(tt.level),
+				WithSource(tt.addSource),
+				WithDebugStackTrace(tt.debugStack),
+			)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				tt.log(logger)
+			}
+		})
+	}
+}

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,43 @@
+package log
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestSetLevelUpdatesCurrentLevel(t *testing.T) {
+	old := SetLevel(slog.LevelWarn)
+	t.Cleanup(func() {
+		SetLevel(old)
+	})
+
+	if got := Level(); got != slog.LevelWarn {
+		t.Fatalf("Level() = %v, want %v", got, slog.LevelWarn)
+	}
+}
+
+func TestPanicContextPanicsWithMessage(t *testing.T) {
+	defer func() {
+		recovered := recover()
+		if recovered != "boom" {
+			t.Fatalf("panic = %v, want %q", recovered, "boom")
+		}
+	}()
+
+	std.PanicContext(context.Background(), "boom")
+}
+
+func TestInfoUsesConfiguredHandler(t *testing.T) {
+	var buf bytes.Buffer
+	std.SetJSONHandler(&buf)
+	t.Cleanup(NewJSONHandler)
+
+	Info("hello")
+
+	if !strings.Contains(buf.String(), "\"msg\":\"hello\"") {
+		t.Fatalf("expected message in output, got %q", buf.String())
+	}
+}

--- a/log_test.go
+++ b/log_test.go
@@ -3,8 +3,10 @@ package log
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -39,6 +41,47 @@ func TestInfoUsesConfiguredHandler(t *testing.T) {
 
 	if !strings.Contains(buf.String(), "\"msg\":\"hello\"") {
 		t.Fatalf("expected message in output, got %q", buf.String())
+	}
+}
+
+func TestInstanceJSONOutputIncludesLevelMessageAndSource(t *testing.T) {
+	var buf bytes.Buffer
+	instance := New(
+		WithJSONHandler(&buf),
+		WithLevel(slog.LevelInfo),
+	)
+
+	instance.Info("hello", "request_id", "abc")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v; output = %q", err, buf.String())
+	}
+	if entry["level"] != "INFO" {
+		t.Fatalf("level = %v, want INFO", entry["level"])
+	}
+	if entry["msg"] != "hello" {
+		t.Fatalf("msg = %v, want hello", entry["msg"])
+	}
+	if entry["request_id"] != "abc" {
+		t.Fatalf("request_id = %v, want abc", entry["request_id"])
+	}
+	if _, ok := entry["source"].(map[string]any); !ok {
+		t.Fatalf("expected source object in output, got %v", entry["source"])
+	}
+}
+
+func TestDisabledLevelDoesNotWrite(t *testing.T) {
+	var buf bytes.Buffer
+	instance := New(
+		WithJSONHandler(&buf),
+		WithLevel(slog.LevelWarn),
+	)
+
+	instance.Info("hidden")
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("expected no output for disabled level, got %q", got)
 	}
 }
 
@@ -79,4 +122,28 @@ func TestDebugStackTraceIsOptIn(t *testing.T) {
 	if !strings.Contains(withStack.String(), "stack_trace") {
 		t.Fatalf("expected debug stack trace when enabled, got %q", withStack.String())
 	}
+}
+
+func TestLoggerSupportsConcurrentConfigurationAndLogging(t *testing.T) {
+	var buf bytes.Buffer
+	instance := New(
+		WithJSONHandler(&buf),
+		WithLevel(slog.LevelDebug),
+	)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 25; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			instance.SetSource(i%2 == 0)
+			instance.SetDebugStackTrace(i%3 == 0)
+			instance.SetCalldepth(3)
+		}(i)
+		go func() {
+			defer wg.Done()
+			instance.Debug("hello")
+		}()
+	}
+	wg.Wait()
 }

--- a/log_test.go
+++ b/log_test.go
@@ -41,3 +41,42 @@ func TestInfoUsesConfiguredHandler(t *testing.T) {
 		t.Fatalf("expected message in output, got %q", buf.String())
 	}
 }
+
+func TestNewSupportsDisablingSource(t *testing.T) {
+	var buf bytes.Buffer
+	instance := New(
+		WithJSONHandler(&buf),
+		WithSource(false),
+	)
+
+	instance.Info("hello")
+
+	if strings.Contains(buf.String(), "\"source\"") {
+		t.Fatalf("expected source metadata to be disabled, got %q", buf.String())
+	}
+}
+
+func TestDebugStackTraceIsOptIn(t *testing.T) {
+	var withoutStack bytes.Buffer
+	instance := New(
+		WithJSONHandler(&withoutStack),
+		WithLevel(slog.LevelDebug),
+	)
+	instance.Debug("hello")
+
+	if strings.Contains(withoutStack.String(), "stack_trace") {
+		t.Fatalf("expected debug stack trace to be disabled by default, got %q", withoutStack.String())
+	}
+
+	var withStack bytes.Buffer
+	instanceWithStack := New(
+		WithJSONHandler(&withStack),
+		WithLevel(slog.LevelDebug),
+		WithDebugStackTrace(true),
+	)
+	instanceWithStack.Debug("hello")
+
+	if !strings.Contains(withStack.String(), "stack_trace") {
+		t.Fatalf("expected debug stack trace when enabled, got %q", withStack.String())
+	}
+}

--- a/logger/customs.go
+++ b/logger/customs.go
@@ -15,3 +15,21 @@ var LevelNames = map[slog.Leveler]string{
 	LevelFatal: "FATAL",
 	LevelPanic: "PANIC",
 }
+
+// ReplaceAttr normalizes custom levels before the handler encodes them.
+func ReplaceAttr(_ []string, attr slog.Attr) slog.Attr {
+	if attr.Key != slog.LevelKey {
+		return attr
+	}
+
+	level, ok := attr.Value.Any().(slog.Level)
+	if !ok {
+		return attr
+	}
+
+	if name, found := LevelNames[level]; found {
+		attr.Value = slog.StringValue(name)
+	}
+
+	return attr
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -13,13 +13,53 @@ import (
 // Priority represents the level of importance for log messages. Higher values indicate greater importance.
 type Priority int8
 
+// Option configures a Logger instance.
+type Option func(*Logger)
+
 // Logger manages logging operations with various log levels and modes.
 type Logger struct {
 	calldepth int // Number of stack frames to ascend when generating log entries.
 	prod      bool
 	level     *slog.LevelVar
+	addSource bool
+	debugStack bool
 	mu        sync.RWMutex
 	logger    *slog.Logger
+}
+
+// WithLevel sets the initial logging level.
+func WithLevel(level slog.Level) Option {
+	return func(l *Logger) {
+		l.level.Set(level)
+	}
+}
+
+// WithSource controls whether source metadata is attached to log records.
+func WithSource(enabled bool) Option {
+	return func(l *Logger) {
+		l.addSource = enabled
+	}
+}
+
+// WithDebugStackTrace controls whether debug logs include a stack trace.
+func WithDebugStackTrace(enabled bool) Option {
+	return func(l *Logger) {
+		l.debugStack = enabled
+	}
+}
+
+// WithJSONHandler configures a JSON handler that writes to w.
+func WithJSONHandler(w io.Writer) Option {
+	return func(l *Logger) {
+		l.SetJSONHandler(w)
+	}
+}
+
+// WithTextHandler configures a text handler that writes to w.
+func WithTextHandler(w io.Writer) Option {
+	return func(l *Logger) {
+		l.SetTextHandler(w)
+	}
 }
 
 // New creates and initializes a new Logger instance.
@@ -35,8 +75,20 @@ func New(calldepth int, _ []uintptr, levels ...*slog.LevelVar) *Logger {
 	l := &Logger{
 		calldepth: calldepth,
 		level:     level,
+		addSource: true,
 	}
 	l.SetJSONHandler(os.Stderr)
+	return l
+}
+
+// NewWithOptions creates a new Logger instance using functional options.
+func NewWithOptions(opts ...Option) *Logger {
+	l := New(3, nil)
+	for _, opt := range opts {
+		if opt != nil {
+			opt(l)
+		}
+	}
 	return l
 }
 
@@ -50,6 +102,24 @@ func (l *Logger) setBackend(next *slog.Logger) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.logger = next
+}
+
+func (l *Logger) sourceAttr(withStack bool) slog.Attr {
+	if !l.addSource {
+		return slog.Attr{}
+	}
+	if withStack {
+		return sourceWithStackTrace(l.calldepth + 1)
+	}
+	return source(l.calldepth + 1)
+}
+
+func (l *Logger) appendSource(args []any, withStack bool) []any {
+	attr := l.sourceAttr(withStack)
+	if attr.Key == "" {
+		return args
+	}
+	return append(args, attr)
 }
 
 // SetJSONHandler configures the logger to emit JSON logs to the provided writer.
@@ -72,103 +142,89 @@ func (l *Logger) SetTextHandler(w io.Writer) {
 
 // Debug logs a debug-level message with optional arguments.
 func (l *Logger) Debug(msg string, args ...any) {
-	source := sourceWithStackTrace(l.calldepth + 1)
-	args = append(args, source)
+	args = l.appendSource(args, l.debugStack)
 	l.backend().Debug(msg, args...)
 }
 
 // DebugContext logs a debug-level message with optional arguments and context.
 func (l *Logger) DebugContext(ctx context.Context, msg string, args ...interface{}) {
-	source := sourceWithStackTrace(l.calldepth + 1)
-	args = append(args, source)
+	args = l.appendSource(args, l.debugStack)
 	l.backend().DebugContext(ctx, msg, args...)
 }
 
 // Warn logs a warning-level message with optional arguments.
 func (l *Logger) Warn(msg string, args ...any) {
-	source := source(l.calldepth + 1)
-	args = append(args, source)
+	args = l.appendSource(args, false)
 	l.backend().Warn(msg, args...)
 }
 
 // WarnContext logs a warning-level message with optional arguments and context.
 func (l *Logger) WarnContext(ctx context.Context, msg string, args ...any) {
-	source := source(l.calldepth + 1)
-	args = append(args, source)
+	args = l.appendSource(args, false)
 	l.backend().WarnContext(ctx, msg, args...)
 }
 
 // Error logs an error-level message with optional arguments.
 func (l *Logger) Error(msg string, args ...any) {
-	source := source(l.calldepth + 1)
-	args = append(args, source)
+	args = l.appendSource(args, false)
 	l.backend().Error(msg, args...)
 }
 
 // ErrorContext logs an error-level message with optional arguments and context.
 func (l *Logger) ErrorContext(ctx context.Context, msg string, args ...any) {
-	source := source(l.calldepth + 1)
-	args = append(args, source)
+	args = l.appendSource(args, false)
 	l.backend().ErrorContext(ctx, msg, args...)
 }
 
 // Panic logs a panic-level message, then panics with the message.
 func (l *Logger) Panic(msg string, args ...any) {
-	source := source(l.calldepth + 1)
-	args = append(args, source)
+	args = l.appendSource(args, false)
 	l.backend().Log(context.Background(), LevelPanic, msg, args...)
 	panic(msg)
 }
 
 // PanicContext logs a panic-level message with context, then panics with the message.
 func (l *Logger) PanicContext(ctx context.Context, msg string, args ...any) {
-	source := source(l.calldepth + 1)
-	args = append(args, source)
+	args = l.appendSource(args, false)
 	l.backend().Log(ctx, LevelPanic, msg, args...)
 	panic(msg)
 }
 
 // Fatal logs a fatal-level message, then exits the application.
 func (l *Logger) Fatal(msg string, args ...any) {
-	source := source(l.calldepth + 1)
-	args = append(args, source)
+	args = l.appendSource(args, false)
 	l.backend().Log(context.Background(), LevelFatal, msg, args...)
 	os.Exit(1)
 }
 
 // FatalContext logs a fatal-level message with context, then exits the application.
 func (l *Logger) FatalContext(ctx context.Context, msg string, args ...any) {
-	source := source(l.calldepth + 1)
-	args = append(args, source)
+	args = l.appendSource(args, false)
 	l.backend().Log(ctx, LevelFatal, msg, args...)
 	os.Exit(1)
 }
 
 // Print logs a trace-level message with optional arguments.
 func (l *Logger) Print(msg string, args ...any) {
-	source := source(l.calldepth + 1)
-	args = append(args, source)
+	args = l.appendSource(args, false)
 	l.backend().Log(context.Background(), LevelTrace, msg, args...)
 }
 
 // PrintContext logs a trace-level message with context and optional arguments.
 func (l *Logger) PrintContext(ctx context.Context, msg string, args ...any) {
-	source := source(l.calldepth + 1)
-	args = append(args, source)
+	args = l.appendSource(args, false)
 	l.backend().Log(ctx, LevelTrace, msg, args...)
 }
 
 // Info logs an info-level message with optional arguments.
 func (l *Logger) Info(msg string, args ...any) {
-	source := source(l.calldepth + 1)
-	args = append(args, source)
+	args = l.appendSource(args, false)
 	l.backend().Info(msg, args...)
 }
 
 // InfoContext logs an info-level message with context and optional arguments.
 func (l *Logger) InfoContext(ctx context.Context, msg string, args ...any) {
-	source := source(l.calldepth + 1)
-	args = append(args, source)
+	args = l.appendSource(args, false)
 	l.backend().InfoContext(ctx, msg, args...)
 }
 
@@ -180,6 +236,16 @@ func (l *Logger) StackTrace() slog.Attr {
 // SetCalldepth configures the number of stack frames to ascend for logging.
 func (l *Logger) SetCalldepth(calldepth int) {
 	l.calldepth = calldepth
+}
+
+// SetSource controls whether source metadata is attached to log records.
+func (l *Logger) SetSource(enabled bool) {
+	l.addSource = enabled
+}
+
+// SetDebugStackTrace controls whether debug logs include a stack trace.
+func (l *Logger) SetDebugStackTrace(enabled bool) {
+	l.debugStack = enabled
 }
 
 // SetLevel sets the logging level for the Logger instance and returns the previous level.

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -4,9 +4,10 @@ package logger
 
 import (
 	"context"
-	"os"
-
+	"io"
 	"log/slog"
+	"os"
+	"sync"
 )
 
 // Priority represents the level of importance for log messages. Higher values indicate greater importance.
@@ -14,192 +15,176 @@ type Priority int8
 
 // Logger manages logging operations with various log levels and modes.
 type Logger struct {
-	calldepth int       // Number of stack frames to ascend when generating log entries.
-	pc        []uintptr // Stack trace information used for logging.
-	prod      bool      // Indicates whether the logger is in production mode.
+	calldepth int // Number of stack frames to ascend when generating log entries.
+	prod      bool
+	level     *slog.LevelVar
+	mu        sync.RWMutex
+	logger    *slog.Logger
 }
 
 // New creates and initializes a new Logger instance.
 // calldepth: Number of stack frames to ascend for log entries.
-// pc: A slice of uintptr used to store stack trace information.
-func New(calldepth int, pc []uintptr) *Logger {
-	return &Logger{
-		calldepth: calldepth,
-		pc:        pc,
+// pc: Deprecated and ignored. Kept for backward compatibility.
+func New(calldepth int, _ []uintptr, levels ...*slog.LevelVar) *Logger {
+	level := new(slog.LevelVar)
+	level.Set(slog.LevelDebug)
+	if len(levels) > 0 && levels[0] != nil {
+		level = levels[0]
 	}
+
+	l := &Logger{
+		calldepth: calldepth,
+		level:     level,
+	}
+	l.SetJSONHandler(os.Stderr)
+	return l
+}
+
+func (l *Logger) backend() *slog.Logger {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.logger
+}
+
+func (l *Logger) setBackend(next *slog.Logger) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.logger = next
+}
+
+// SetJSONHandler configures the logger to emit JSON logs to the provided writer.
+func (l *Logger) SetJSONHandler(w io.Writer) {
+	opts := &slog.HandlerOptions{
+		Level:       l.level,
+		ReplaceAttr: ReplaceAttr,
+	}
+	l.setBackend(slog.New(slog.NewJSONHandler(w, opts)))
+}
+
+// SetTextHandler configures the logger to emit text logs to the provided writer.
+func (l *Logger) SetTextHandler(w io.Writer) {
+	opts := &slog.HandlerOptions{
+		Level:       l.level,
+		ReplaceAttr: ReplaceAttr,
+	}
+	l.setBackend(slog.New(slog.NewTextHandler(w, opts)))
 }
 
 // Debug logs a debug-level message with optional arguments.
-// msg: The message to log.
-// args: Additional arguments to format the message.
 func (l *Logger) Debug(msg string, args ...any) {
-	source := sourceWithStackTrace(l.calldepth+1, l.pc)
+	source := sourceWithStackTrace(l.calldepth + 1)
 	args = append(args, source)
-	slog.Debug(msg, args...)
+	l.backend().Debug(msg, args...)
 }
 
 // DebugContext logs a debug-level message with optional arguments and context.
-// ctx: The context for the log entry.
-// msg: The message to log.
-// args: Additional arguments to format the message.
 func (l *Logger) DebugContext(ctx context.Context, msg string, args ...interface{}) {
-	source := sourceWithStackTrace(l.calldepth+1, l.pc)
+	source := sourceWithStackTrace(l.calldepth + 1)
 	args = append(args, source)
-	slog.DebugContext(ctx, msg, args...)
+	l.backend().DebugContext(ctx, msg, args...)
 }
 
 // Warn logs a warning-level message with optional arguments.
-// msg: The message to log.
-// args: Additional arguments to format the message.
 func (l *Logger) Warn(msg string, args ...any) {
-	source := source(l.calldepth+1, l.pc)
+	source := source(l.calldepth + 1)
 	args = append(args, source)
-	slog.Warn(msg, args...)
+	l.backend().Warn(msg, args...)
 }
 
 // WarnContext logs a warning-level message with optional arguments and context.
-// ctx: The context for the log entry.
-// msg: The message to log.
-// args: Additional arguments to format the message.
 func (l *Logger) WarnContext(ctx context.Context, msg string, args ...any) {
-	source := source(l.calldepth+1, l.pc)
+	source := source(l.calldepth + 1)
 	args = append(args, source)
-	slog.WarnContext(ctx, msg, args...)
+	l.backend().WarnContext(ctx, msg, args...)
 }
 
 // Error logs an error-level message with optional arguments.
-// msg: The message to log.
-// args: Additional arguments to format the message.
 func (l *Logger) Error(msg string, args ...any) {
-	source := source(l.calldepth+1, l.pc)
+	source := source(l.calldepth + 1)
 	args = append(args, source)
-	slog.Error(msg, args...)
+	l.backend().Error(msg, args...)
 }
 
 // ErrorContext logs an error-level message with optional arguments and context.
-// ctx: The context for the log entry.
-// msg: The message to log.
-// args: Additional arguments to format the message.
 func (l *Logger) ErrorContext(ctx context.Context, msg string, args ...any) {
-	source := source(l.calldepth+1, l.pc)
+	source := source(l.calldepth + 1)
 	args = append(args, source)
-	slog.ErrorContext(ctx, msg, args...)
+	l.backend().ErrorContext(ctx, msg, args...)
 }
 
 // Panic logs a panic-level message, then panics with the message.
-// msg: The message to log.
-// args: Additional arguments to format the message.
 func (l *Logger) Panic(msg string, args ...any) {
-	source := source(l.calldepth+1, l.pc)
+	source := source(l.calldepth + 1)
 	args = append(args, source)
-	ctx := context.Background()
-	slog.Log(ctx, LevelPanic, msg, args...)
+	l.backend().Log(context.Background(), LevelPanic, msg, args...)
 	panic(msg)
 }
 
-// PanicC logs a panic-level message with context, then panics with the context.
-// ctx: The context for the log entry.
-// msg: The message to log.
-// args: Additional arguments to format the message.
+// PanicContext logs a panic-level message with context, then panics with the message.
 func (l *Logger) PanicContext(ctx context.Context, msg string, args ...any) {
-	source := source(l.calldepth+1, l.pc)
+	source := source(l.calldepth + 1)
 	args = append(args, source)
-	slog.Log(ctx, LevelPanic, msg, args...)
-	panic(ctx)
+	l.backend().Log(ctx, LevelPanic, msg, args...)
+	panic(msg)
 }
 
 // Fatal logs a fatal-level message, then exits the application.
-// msg: The message to log.
-// args: Additional arguments to format the message.
 func (l *Logger) Fatal(msg string, args ...any) {
-	source := source(l.calldepth+1, l.pc)
+	source := source(l.calldepth + 1)
 	args = append(args, source)
-	ctx := context.Background()
-	slog.Log(ctx, LevelFatal, msg, args...)
+	l.backend().Log(context.Background(), LevelFatal, msg, args...)
 	os.Exit(1)
 }
 
-// FatalC logs a fatal-level message with context, then exits the application.
-// ctx: The context for the log entry.
-// msg: The message to log.
-// args: Additional arguments to format the message.
+// FatalContext logs a fatal-level message with context, then exits the application.
 func (l *Logger) FatalContext(ctx context.Context, msg string, args ...any) {
-	source := source(l.calldepth+1, l.pc)
+	source := source(l.calldepth + 1)
 	args = append(args, source)
-	slog.Log(ctx, LevelFatal, msg, args...)
+	l.backend().Log(ctx, LevelFatal, msg, args...)
 	os.Exit(1)
 }
 
 // Print logs a trace-level message with optional arguments.
-// msg: The message to log.
-// args: Additional arguments to format the message.
 func (l *Logger) Print(msg string, args ...any) {
-	source := source(l.calldepth+1, l.pc)
+	source := source(l.calldepth + 1)
 	args = append(args, source)
-	ctx := context.Background()
-	slog.Log(ctx, LevelTrace, msg, args...)
+	l.backend().Log(context.Background(), LevelTrace, msg, args...)
 }
 
-// PrintC logs a trace-level message with context and optional arguments.
-// ctx: The context for the log entry.
-// msg: The message to log.
-// args: Additional arguments to format the message.
+// PrintContext logs a trace-level message with context and optional arguments.
 func (l *Logger) PrintContext(ctx context.Context, msg string, args ...any) {
-	source := source(l.calldepth+1, l.pc)
+	source := source(l.calldepth + 1)
 	args = append(args, source)
-	slog.Log(ctx, LevelTrace, msg, args...)
+	l.backend().Log(ctx, LevelTrace, msg, args...)
 }
 
 // Info logs an info-level message with optional arguments.
-// msg: The message to log.
-// args: Additional arguments to format the message.
 func (l *Logger) Info(msg string, args ...any) {
-	source := source(l.calldepth+1, l.pc)
+	source := source(l.calldepth + 1)
 	args = append(args, source)
-	slog.Info(msg, args...)
+	l.backend().Info(msg, args...)
 }
 
-// InfoC logs an info-level message with context and optional arguments.
-// ctx: The context for the log entry.
-// msg: The message to log.
-// args: Additional arguments to format the message.
+// InfoContext logs an info-level message with context and optional arguments.
 func (l *Logger) InfoContext(ctx context.Context, msg string, args ...any) {
-	source := source(l.calldepth+1, l.pc)
+	source := source(l.calldepth + 1)
 	args = append(args, source)
-	slog.InfoContext(ctx, msg, args...)
+	l.backend().InfoContext(ctx, msg, args...)
 }
 
 // StackTrace provides a stack trace of up to 10 layers from where the error or incident was generated.
 func (l *Logger) StackTrace() slog.Attr {
-	return sourceWithStackTrace(l.calldepth+1, l.pc)
+	return sourceWithStackTrace(l.calldepth + 1)
 }
 
 // SetCalldepth configures the number of stack frames to ascend for logging.
-// calldepth: The number of stack frames to ascend.
 func (l *Logger) SetCalldepth(calldepth int) {
 	l.calldepth = calldepth
 }
 
-// SetLevel sets the logging level for the Logger instance.
-// This method updates the log level to the specified level and returns the previous log level.
-//
-// Parameters:
-//
-//	level (slog.Level) - The new log level to be set. This determines the severity of the logs
-//	                     that will be captured. Common log levels include DEBUG, INFO, WARN, and ERROR.
-//
-// Returns:
-//
-//	oldLevel (slog.Level) - The previous log level before it was updated. This can be used to restore
-//	                        the previous log level if needed.
-//
-// Example usage:
-//
-//	logger := &Logger{}
-//	oldLevel := logger.SetLevel(slog.INFO)
-//	// The log level is now set to INFO
-//	// You can restore the old level if needed
-//	logger.SetLevel(oldLevel)
+// SetLevel sets the logging level for the Logger instance and returns the previous level.
 func (l *Logger) SetLevel(level slog.Level) (oldLevel slog.Level) {
-	return slog.SetLogLoggerLevel(level)
+	oldLevel = l.level.Level()
+	l.level.Set(level)
+	return oldLevel
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -11,6 +11,8 @@ import (
 )
 
 // Priority represents the level of importance for log messages. Higher values indicate greater importance.
+//
+// Deprecated: use slog.Level instead.
 type Priority int8
 
 // Option configures a Logger instance.
@@ -18,13 +20,19 @@ type Option func(*Logger)
 
 // Logger manages logging operations with various log levels and modes.
 type Logger struct {
-	calldepth int // Number of stack frames to ascend when generating log entries.
-	prod      bool
-	level     *slog.LevelVar
-	addSource bool
+	calldepth  int // Number of stack frames to ascend when generating log entries.
+	level      *slog.LevelVar
+	addSource  bool
 	debugStack bool
-	mu        sync.RWMutex
-	logger    *slog.Logger
+	mu         sync.RWMutex
+	logger     *slog.Logger
+}
+
+type loggerConfig struct {
+	calldepth  int
+	addSource  bool
+	debugStack bool
+	logger     *slog.Logger
 }
 
 // WithLevel sets the initial logging level.
@@ -92,10 +100,15 @@ func NewWithOptions(opts ...Option) *Logger {
 	return l
 }
 
-func (l *Logger) backend() *slog.Logger {
+func (l *Logger) snapshot() loggerConfig {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
-	return l.logger
+	return loggerConfig{
+		calldepth:  l.calldepth,
+		addSource:  l.addSource,
+		debugStack: l.debugStack,
+		logger:     l.logger,
+	}
 }
 
 func (l *Logger) setBackend(next *slog.Logger) {
@@ -104,22 +117,35 @@ func (l *Logger) setBackend(next *slog.Logger) {
 	l.logger = next
 }
 
-func (l *Logger) sourceAttr(withStack bool) slog.Attr {
-	if !l.addSource {
+func (c loggerConfig) sourceAttr(withStack bool) slog.Attr {
+	if !c.addSource {
 		return slog.Attr{}
 	}
 	if withStack {
-		return sourceWithStackTrace(l.calldepth + 1)
+		return sourceWithStackTrace(c.calldepth + 1)
 	}
-	return source(l.calldepth + 1)
+	return source(c.calldepth + 1)
 }
 
-func (l *Logger) appendSource(args []any, withStack bool) []any {
-	attr := l.sourceAttr(withStack)
+func (c loggerConfig) appendSource(args []any, withStack bool) []any {
+	attr := c.sourceAttr(withStack)
 	if attr.Key == "" {
 		return args
 	}
 	return append(args, attr)
+}
+
+func (l *Logger) log(ctx context.Context, level slog.Level, msg string, args []any, withStack bool) {
+	cfg := l.snapshot()
+	logWithConfig(ctx, level, msg, args, cfg, withStack)
+}
+
+func logWithConfig(ctx context.Context, level slog.Level, msg string, args []any, cfg loggerConfig, withStack bool) {
+	if cfg.logger == nil || !cfg.logger.Enabled(ctx, level) {
+		return
+	}
+	args = cfg.appendSource(args, withStack)
+	cfg.logger.Log(ctx, level, msg, args...)
 }
 
 // SetJSONHandler configures the logger to emit JSON logs to the provided writer.
@@ -142,109 +168,103 @@ func (l *Logger) SetTextHandler(w io.Writer) {
 
 // Debug logs a debug-level message with optional arguments.
 func (l *Logger) Debug(msg string, args ...any) {
-	args = l.appendSource(args, l.debugStack)
-	l.backend().Debug(msg, args...)
+	cfg := l.snapshot()
+	logWithConfig(context.Background(), slog.LevelDebug, msg, args, cfg, cfg.debugStack)
 }
 
 // DebugContext logs a debug-level message with optional arguments and context.
 func (l *Logger) DebugContext(ctx context.Context, msg string, args ...interface{}) {
-	args = l.appendSource(args, l.debugStack)
-	l.backend().DebugContext(ctx, msg, args...)
+	cfg := l.snapshot()
+	logWithConfig(ctx, slog.LevelDebug, msg, args, cfg, cfg.debugStack)
 }
 
 // Warn logs a warning-level message with optional arguments.
 func (l *Logger) Warn(msg string, args ...any) {
-	args = l.appendSource(args, false)
-	l.backend().Warn(msg, args...)
+	l.log(context.Background(), slog.LevelWarn, msg, args, false)
 }
 
 // WarnContext logs a warning-level message with optional arguments and context.
 func (l *Logger) WarnContext(ctx context.Context, msg string, args ...any) {
-	args = l.appendSource(args, false)
-	l.backend().WarnContext(ctx, msg, args...)
+	l.log(ctx, slog.LevelWarn, msg, args, false)
 }
 
 // Error logs an error-level message with optional arguments.
 func (l *Logger) Error(msg string, args ...any) {
-	args = l.appendSource(args, false)
-	l.backend().Error(msg, args...)
+	l.log(context.Background(), slog.LevelError, msg, args, false)
 }
 
 // ErrorContext logs an error-level message with optional arguments and context.
 func (l *Logger) ErrorContext(ctx context.Context, msg string, args ...any) {
-	args = l.appendSource(args, false)
-	l.backend().ErrorContext(ctx, msg, args...)
+	l.log(ctx, slog.LevelError, msg, args, false)
 }
 
 // Panic logs a panic-level message, then panics with the message.
 func (l *Logger) Panic(msg string, args ...any) {
-	args = l.appendSource(args, false)
-	l.backend().Log(context.Background(), LevelPanic, msg, args...)
+	l.log(context.Background(), LevelPanic, msg, args, false)
 	panic(msg)
 }
 
 // PanicContext logs a panic-level message with context, then panics with the message.
 func (l *Logger) PanicContext(ctx context.Context, msg string, args ...any) {
-	args = l.appendSource(args, false)
-	l.backend().Log(ctx, LevelPanic, msg, args...)
+	l.log(ctx, LevelPanic, msg, args, false)
 	panic(msg)
 }
 
 // Fatal logs a fatal-level message, then exits the application.
 func (l *Logger) Fatal(msg string, args ...any) {
-	args = l.appendSource(args, false)
-	l.backend().Log(context.Background(), LevelFatal, msg, args...)
+	l.log(context.Background(), LevelFatal, msg, args, false)
 	os.Exit(1)
 }
 
 // FatalContext logs a fatal-level message with context, then exits the application.
 func (l *Logger) FatalContext(ctx context.Context, msg string, args ...any) {
-	args = l.appendSource(args, false)
-	l.backend().Log(ctx, LevelFatal, msg, args...)
+	l.log(ctx, LevelFatal, msg, args, false)
 	os.Exit(1)
 }
 
 // Print logs a trace-level message with optional arguments.
 func (l *Logger) Print(msg string, args ...any) {
-	args = l.appendSource(args, false)
-	l.backend().Log(context.Background(), LevelTrace, msg, args...)
+	l.log(context.Background(), LevelTrace, msg, args, false)
 }
 
 // PrintContext logs a trace-level message with context and optional arguments.
 func (l *Logger) PrintContext(ctx context.Context, msg string, args ...any) {
-	args = l.appendSource(args, false)
-	l.backend().Log(ctx, LevelTrace, msg, args...)
+	l.log(ctx, LevelTrace, msg, args, false)
 }
 
 // Info logs an info-level message with optional arguments.
 func (l *Logger) Info(msg string, args ...any) {
-	args = l.appendSource(args, false)
-	l.backend().Info(msg, args...)
+	l.log(context.Background(), slog.LevelInfo, msg, args, false)
 }
 
 // InfoContext logs an info-level message with context and optional arguments.
 func (l *Logger) InfoContext(ctx context.Context, msg string, args ...any) {
-	args = l.appendSource(args, false)
-	l.backend().InfoContext(ctx, msg, args...)
+	l.log(ctx, slog.LevelInfo, msg, args, false)
 }
 
 // StackTrace provides a stack trace of up to 10 layers from where the error or incident was generated.
 func (l *Logger) StackTrace() slog.Attr {
-	return sourceWithStackTrace(l.calldepth + 1)
+	return sourceWithStackTrace(l.snapshot().calldepth + 1)
 }
 
 // SetCalldepth configures the number of stack frames to ascend for logging.
 func (l *Logger) SetCalldepth(calldepth int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	l.calldepth = calldepth
 }
 
 // SetSource controls whether source metadata is attached to log records.
 func (l *Logger) SetSource(enabled bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	l.addSource = enabled
 }
 
 // SetDebugStackTrace controls whether debug logs include a stack trace.
 func (l *Logger) SetDebugStackTrace(enabled bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	l.debugStack = enabled
 }
 

--- a/logger/utils.go
+++ b/logger/utils.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -27,16 +28,17 @@ func itoa(buf *[]byte, i int64, wid int) {
 // If the Record was created without the necessary information,
 // or if the location is unavailable, it returns a non-nil *Source
 // with zero fields.
-func source(calldepth int, pc []uintptr) slog.Attr {
+func source(calldepth int) slog.Attr {
+	pc := make([]uintptr, 1)
 	num := runtime.Callers(calldepth, pc)
 	fs := runtime.CallersFrames(pc[0:num])
 	f, _ := fs.Next()
 	var as []any
 	if f.Function != "" {
-		as = append(as, slog.String("func", f.Function))
+		as = append(as, slog.String("func", getFuncName(f.Function)))
 	}
 	if f.File != "" {
-		as = append(as, slog.String("file", f.File))
+		as = append(as, slog.String("file", filepath.Base(f.File)))
 	}
 	if f.Line != 0 {
 		as = append(as, slog.Int("line", f.Line))
@@ -44,21 +46,22 @@ func source(calldepth int, pc []uintptr) slog.Attr {
 	return slog.Group("source", as...)
 }
 
-func sourceWithStackTrace(calldepth int, pc []uintptr) slog.Attr {
+func sourceWithStackTrace(calldepth int) slog.Attr {
+	pc := make([]uintptr, 10)
 	num := runtime.Callers(calldepth, pc)
 	fs := runtime.CallersFrames(pc[0:num])
 	f, _ := fs.Next()
 	var as []any
 	if f.Function != "" {
-		as = append(as, slog.String("func", f.Function))
+		as = append(as, slog.String("func", getFuncName(f.Function)))
 	}
 	if f.File != "" {
-		as = append(as, slog.String("file", f.File))
+		as = append(as, slog.String("file", filepath.Base(f.File)))
 	}
 	if f.Line != 0 {
 		as = append(as, slog.Int("line", f.Line))
 	}
-	stack := getStackTrace(calldepth+1, pc)
+	stack := getStackTrace(calldepth + 1)
 	as = append(as, stack)
 	return slog.Group("source", as...)
 }
@@ -68,7 +71,8 @@ func getFuncName(function string) string {
 	return function[p+1:]
 }
 
-func getStackTrace(calldepth int, pc []uintptr) slog.Attr {
+func getStackTrace(calldepth int) slog.Attr {
+	pc := make([]uintptr, 10)
 	num := runtime.Callers(calldepth, pc)
 	frames := runtime.CallersFrames(pc[0:num])
 	var as []any
@@ -78,11 +82,10 @@ func getStackTrace(calldepth int, pc []uintptr) slog.Attr {
 		if found {
 			var newbuf []byte
 			newbuf = newbuf[:0]
-			newbuf = append(newbuf, frame.File...)
+			newbuf = append(newbuf, filepath.Base(frame.File)...)
 			newbuf = append(newbuf, ':')
 			itoa(&newbuf, int64(frame.Line), 2)
-			p := strings.LastIndex(frame.Function, ".")
-			function := frame.Function[p+1:]
+			function := getFuncName(frame.Function)
 			newbuf = append(newbuf, ' ')
 			newbuf = append(newbuf, '(')
 			newbuf = append(newbuf, function...)

--- a/logger_test.go
+++ b/logger_test.go
@@ -8,5 +8,4 @@ import (
 
 func TestLogger_Output(t *testing.T) {
 	log.Error("Test message")
-	log.Fatal("Test message")
 }

--- a/otel/handler.go
+++ b/otel/handler.go
@@ -41,9 +41,14 @@ type OtelHandler struct {
 	NoBaggage bool
 	// NoTraceEvents determines whether to record an event for every log on the active trace.
 	NoTraceEvents bool
+	// BaggageFilter can allow, drop, or redact baggage members before they are logged.
+	BaggageFilter BaggageFilter
 }
 
 type OtelHandlerOpt func(handler *OtelHandler)
+
+// BaggageFilter returns the value to log and whether the member should be included.
+type BaggageFilter func(key, value string) (string, bool)
 
 // HandlerFn defines the handler used by slog.Handler as return value.
 type HandlerFn func(slog.Handler) slog.Handler
@@ -62,10 +67,44 @@ func WithNoTraceEvents(noTraceEvents bool) OtelHandlerOpt {
 	}
 }
 
+// WithBaggageFilter configures a baggage filter for selective logging/redaction.
+func WithBaggageFilter(filter BaggageFilter) OtelHandlerOpt {
+	return func(handler *OtelHandler) {
+		handler.BaggageFilter = filter
+	}
+}
+
+// WithBaggageAllowList only logs baggage members whose keys are explicitly listed.
+func WithBaggageAllowList(keys ...string) OtelHandlerOpt {
+	allowed := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		allowed[key] = struct{}{}
+	}
+
+	return WithBaggageFilter(func(key, value string) (string, bool) {
+		_, ok := allowed[key]
+		return value, ok
+	})
+}
+
+// WithBaggageDenyList drops baggage members whose keys are explicitly listed.
+func WithBaggageDenyList(keys ...string) OtelHandlerOpt {
+	denied := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		denied[key] = struct{}{}
+	}
+
+	return WithBaggageFilter(func(key, value string) (string, bool) {
+		_, deniedKey := denied[key]
+		return value, !deniedKey
+	})
+}
+
 // New creates a new OtelHandler to use with log/slog
 func New(next slog.Handler, opts ...OtelHandlerOpt) *OtelHandler {
 	ret := &OtelHandler{
-		Next: next,
+		Next:      next,
+		NoBaggage: true,
 	}
 	for _, opt := range opts {
 		opt(ret)
@@ -89,7 +128,16 @@ func (h OtelHandler) Handle(ctx context.Context, record slog.Record) error {
 		// Adding context baggage members to log record.
 		b := baggage.FromContext(ctx)
 		for _, m := range b.Members() {
-			record.AddAttrs(slog.String(m.Key(), m.Value()))
+			key := m.Key()
+			value := m.Value()
+			if h.BaggageFilter != nil {
+				filteredValue, ok := h.BaggageFilter(key, value)
+				if !ok {
+					continue
+				}
+				value = filteredValue
+			}
+			record.AddAttrs(slog.String(key, value))
 		}
 	}
 
@@ -145,6 +193,7 @@ func (h OtelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 		Next:          h.Next.WithAttrs(attrs),
 		NoBaggage:     h.NoBaggage,
 		NoTraceEvents: h.NoTraceEvents,
+		BaggageFilter: h.BaggageFilter,
 	}
 }
 
@@ -154,6 +203,7 @@ func (h OtelHandler) WithGroup(name string) slog.Handler {
 		Next:          h.Next.WithGroup(name),
 		NoBaggage:     h.NoBaggage,
 		NoTraceEvents: h.NoTraceEvents,
+		BaggageFilter: h.BaggageFilter,
 	}
 }
 

--- a/otel/handler_test.go
+++ b/otel/handler_test.go
@@ -65,3 +65,70 @@ func TestBaggageAllowList(t *testing.T) {
 		t.Fatalf("expected non-allow-listed baggage to be omitted, got %q", output)
 	}
 }
+
+func TestBaggageDenyList(t *testing.T) {
+	var buf bytes.Buffer
+	handler := New(
+		slog.NewJSONHandler(&buf, nil),
+		WithNoBaggage(false),
+		WithBaggageDenyList("token"),
+	)
+	logger := slog.New(handler)
+
+	tenant, err := baggage.NewMember("tenant", "acme")
+	if err != nil {
+		t.Fatalf("NewMember(tenant) error = %v", err)
+	}
+	token, err := baggage.NewMember("token", "secret")
+	if err != nil {
+		t.Fatalf("NewMember(token) error = %v", err)
+	}
+	bag, err := baggage.New(tenant, token)
+	if err != nil {
+		t.Fatalf("baggage.New() error = %v", err)
+	}
+
+	logger.InfoContext(baggage.ContextWithBaggage(context.Background(), bag), "hello")
+
+	output := buf.String()
+	if !strings.Contains(output, "\"tenant\":\"acme\"") {
+		t.Fatalf("expected non-denied baggage in output, got %q", output)
+	}
+	if strings.Contains(output, "\"token\":\"secret\"") {
+		t.Fatalf("expected denied baggage to be omitted, got %q", output)
+	}
+}
+
+func TestBaggageFilterCanRedactValues(t *testing.T) {
+	var buf bytes.Buffer
+	handler := New(
+		slog.NewJSONHandler(&buf, nil),
+		WithNoBaggage(false),
+		WithBaggageFilter(func(key, value string) (string, bool) {
+			if key == "token" {
+				return "redacted", true
+			}
+			return value, true
+		}),
+	)
+	logger := slog.New(handler)
+
+	token, err := baggage.NewMember("token", "secret")
+	if err != nil {
+		t.Fatalf("NewMember(token) error = %v", err)
+	}
+	bag, err := baggage.New(token)
+	if err != nil {
+		t.Fatalf("baggage.New() error = %v", err)
+	}
+
+	logger.InfoContext(baggage.ContextWithBaggage(context.Background(), bag), "hello")
+
+	output := buf.String()
+	if !strings.Contains(output, "\"token\":\"redacted\"") {
+		t.Fatalf("expected redacted baggage in output, got %q", output)
+	}
+	if strings.Contains(output, "secret") {
+		t.Fatalf("expected original secret to be omitted, got %q", output)
+	}
+}

--- a/otel/handler_test.go
+++ b/otel/handler_test.go
@@ -1,0 +1,67 @@
+package otel
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/baggage"
+)
+
+func TestBaggageIsDisabledByDefault(t *testing.T) {
+	var buf bytes.Buffer
+	handler := New(slog.NewJSONHandler(&buf, nil))
+	logger := slog.New(handler)
+
+	member, err := baggage.NewMember("tenant", "acme")
+	if err != nil {
+		t.Fatalf("NewMember() error = %v", err)
+	}
+
+	bag, err := baggage.New(member)
+	if err != nil {
+		t.Fatalf("baggage.New() error = %v", err)
+	}
+
+	logger.InfoContext(baggage.ContextWithBaggage(context.Background(), bag), "hello")
+
+	if strings.Contains(buf.String(), "\"tenant\"") {
+		t.Fatalf("expected baggage to be omitted by default, got %q", buf.String())
+	}
+}
+
+func TestBaggageAllowList(t *testing.T) {
+	var buf bytes.Buffer
+	handler := New(
+		slog.NewJSONHandler(&buf, nil),
+		WithNoBaggage(false),
+		WithBaggageAllowList("tenant"),
+	)
+	logger := slog.New(handler)
+
+	tenant, err := baggage.NewMember("tenant", "acme")
+	if err != nil {
+		t.Fatalf("NewMember(tenant) error = %v", err)
+	}
+	token, err := baggage.NewMember("token", "secret")
+	if err != nil {
+		t.Fatalf("NewMember(token) error = %v", err)
+	}
+
+	bag, err := baggage.New(tenant, token)
+	if err != nil {
+		t.Fatalf("baggage.New() error = %v", err)
+	}
+
+	logger.InfoContext(baggage.ContextWithBaggage(context.Background(), bag), "hello")
+
+	output := buf.String()
+	if !strings.Contains(output, "\"tenant\":\"acme\"") {
+		t.Fatalf("expected allow-listed baggage in output, got %q", output)
+	}
+	if strings.Contains(output, "\"token\":\"secret\"") {
+		t.Fatalf("expected non-allow-listed baggage to be omitted, got %q", output)
+	}
+}

--- a/otel/handler_test.go
+++ b/otel/handler_test.go
@@ -3,12 +3,54 @@ package otel
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"log/slog"
 	"strings"
 	"testing"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 )
+
+type recordedEvent struct {
+	name       string
+	attrs      []attribute.KeyValue
+	stackTrace bool
+}
+
+type recordingSpan struct {
+	noop.Span
+
+	spanContext       trace.SpanContext
+	events            []recordedEvent
+	statusCode        codes.Code
+	statusDescription string
+}
+
+func (s *recordingSpan) IsRecording() bool {
+	return true
+}
+
+func (s *recordingSpan) SpanContext() trace.SpanContext {
+	return s.spanContext
+}
+
+func (s *recordingSpan) AddEvent(name string, options ...trace.EventOption) {
+	cfg := trace.NewEventConfig(options...)
+	s.events = append(s.events, recordedEvent{
+		name:       name,
+		attrs:      cfg.Attributes(),
+		stackTrace: cfg.StackTrace(),
+	})
+}
+
+func (s *recordingSpan) SetStatus(code codes.Code, description string) {
+	s.statusCode = code
+	s.statusDescription = description
+}
 
 func TestBaggageIsDisabledByDefault(t *testing.T) {
 	var buf bytes.Buffer
@@ -131,4 +173,63 @@ func TestBaggageFilterCanRedactValues(t *testing.T) {
 	if strings.Contains(output, "secret") {
 		t.Fatalf("expected original secret to be omitted, got %q", output)
 	}
+}
+
+func TestHandleAddsTraceCorrelationSpanEventAndErrorStatus(t *testing.T) {
+	traceID, err := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	if err != nil {
+		t.Fatalf("TraceIDFromHex() error = %v", err)
+	}
+	spanID, err := trace.SpanIDFromHex("0102030405060708")
+	if err != nil {
+		t.Fatalf("SpanIDFromHex() error = %v", err)
+	}
+
+	var buf bytes.Buffer
+	handler := New(slog.NewJSONHandler(&buf, nil))
+	logger := slog.New(handler)
+	span := &recordingSpan{
+		spanContext: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: traceID,
+			SpanID:  spanID,
+		}),
+	}
+	ctx := trace.ContextWithSpan(context.Background(), span)
+
+	logger.ErrorContext(ctx, "failed", "request_id", "abc")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v; output = %q", err, buf.String())
+	}
+	if entry[TraceIDKey] != traceID.String() {
+		t.Fatalf("trace_id = %v, want %s", entry[TraceIDKey], traceID.String())
+	}
+	if entry[SpanIDKey] != spanID.String() {
+		t.Fatalf("span_id = %v, want %s", entry[SpanIDKey], spanID.String())
+	}
+	if len(span.events) != 1 {
+		t.Fatalf("events len = %d, want 1", len(span.events))
+	}
+	if span.events[0].name != "log.error" {
+		t.Fatalf("event name = %q, want log.error", span.events[0].name)
+	}
+	if got := attrValue(span.events[0].attrs, "request_id"); got != "abc" {
+		t.Fatalf("event request_id = %q, want abc", got)
+	}
+	if span.statusCode != codes.Error {
+		t.Fatalf("status code = %v, want %v", span.statusCode, codes.Error)
+	}
+	if span.statusDescription != "failed" {
+		t.Fatalf("status description = %q, want failed", span.statusDescription)
+	}
+}
+
+func attrValue(attrs []attribute.KeyValue, key string) string {
+	for _, attr := range attrs {
+		if string(attr.Key) == key {
+			return attr.Value.AsString()
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
This pull request modernizes the logging package by refactoring its configuration and usage to leverage Go's `log/slog`, improving its API, documentation, and test coverage. The update removes legacy environment-based configuration, introduces programmatic and instance-based setup, and makes debug stack traces opt-in. OpenTelemetry (OTel) integration is now safer by default, and the package is more extensible and testable.

**API and Configuration Refactor:**
- Introduced a new `config.go` file with a set of functional options (`WithLevel`, `WithSource`, `WithDebugStackTrace`, `WithJSONHandler`, `WithTextHandler`) and a `New` constructor for creating logger instances without affecting global state. Package-level setters for source metadata and debug stack traces are also provided.
- Refactored `log.go` to use a `slog.LevelVar` for dynamic log level management, updated handler initialization, and improved argument validation for error logging. [[1]](diffhunk://#diff-973afd7a3fa6644d1e62a8846c6ee7dde87077ff5c0ee193624f98154eb77687L12-R24) [[2]](diffhunk://#diff-973afd7a3fa6644d1e62a8846c6ee7dde87077ff5c0ee193624f98154eb77687L67-R67) [[3]](diffhunk://#diff-973afd7a3fa6644d1e62a8846c6ee7dde87077ff5c0ee193624f98154eb77687R77-R84)

**Documentation and Usability Improvements:**
- Overhauled `README.md` and `doc.go` to describe the new API, configuration patterns, and OTel best practices. Examples now use the new structured logging output and clarify opt-in features. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R93) [[3]](diffhunk://#diff-a20b1b3b4b2bca5bef2b853a6e3f19def513381f9c7ee68d6979f0435c885dcfL8-R19) [[4]](diffhunk://#diff-a20b1b3b4b2bca5bef2b853a6e3f19def513381f9c7ee68d6979f0435c885dcfL34-R60)
- Added a `RELEASE.md` checklist to ensure future releases maintain quality and documentation standards.

**Testing and Benchmarking:**
- Added comprehensive unit tests in `log_test.go` to verify configuration, output, and concurrency safety.
- Introduced `log_benchmark_test.go` with benchmarks for common logging scenarios, including toggling source metadata and debug stack traces.

**OpenTelemetry and Security:**
- Updated OTel handler defaults to disable baggage logging, with clear guidance and API for allow-listing sensitive context values. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R93) [[2]](diffhunk://#diff-a20b1b3b4b2bca5bef2b853a6e3f19def513381f9c7ee68d6979f0435c885dcfL34-R60)

**Other Notable Changes:**
- Upgraded dependency on `github.com/jgolang/errors` to v0.2.0.
- Added a `ReplaceAttr` function to normalize custom log levels for handler output.
- Updated or removed outdated examples and clarified output in tests and documentation.

These changes provide a more robust, flexible, and secure logging foundation for Go applications.

**References:**  
[[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R1-R46) [[2]](diffhunk://#diff-973afd7a3fa6644d1e62a8846c6ee7dde87077ff5c0ee193624f98154eb77687L12-R24) [[3]](diffhunk://#diff-973afd7a3fa6644d1e62a8846c6ee7dde87077ff5c0ee193624f98154eb77687L67-R67) [[4]](diffhunk://#diff-973afd7a3fa6644d1e62a8846c6ee7dde87077ff5c0ee193624f98154eb77687R77-R84) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R16) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R93) [[7]](diffhunk://#diff-a20b1b3b4b2bca5bef2b853a6e3f19def513381f9c7ee68d6979f0435c885dcfL8-R19) [[8]](diffhunk://#diff-a20b1b3b4b2bca5bef2b853a6e3f19def513381f9c7ee68d6979f0435c885dcfL34-R60) [[9]](diffhunk://#diff-2b1b69303b927a484e02c7fad9fc87d0d3ff0dc22ae1da0ecd0dc935d922a23cR1-R9) [[10]](diffhunk://#diff-066e04539a290a1ee6b1698de1d47961080f363599cd05650614bf6ca1eaa8a6R1-R149) [[11]](diffhunk://#diff-c9b4fb4eaef5feb52c6a8d3f6b3fd26c5a5de2fd9816459807af369cadce373dR1-R67) [[12]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L6-R6) [[13]](diffhunk://#diff-998ae61ea4cdf25a77d370262a577a2672e0bd479a992a69c8f78a7f710f2488R18-R35) [[14]](diffhunk://#diff-c2ade2f386c41794d5ebc57ee49b57a5fca8082e03255e5bff13977cbc061287L26-L27)